### PR TITLE
fixing  `wp_options` table not found issue on getJobs function under wordpress con…

### DIFF
--- a/src/Connections/WordPressConnection.php
+++ b/src/Connections/WordPressConnection.php
@@ -14,7 +14,7 @@ class WordPressConnection extends Connection
 
         return \array_map(function ($result) {
             return \unserialize($result->option_value);
-        }, $wpdb->get_results("SELECT * FROM $optionTable WHERE option_name LIKE 'wpj_job_%' ORDER BY option_id") ?: []);
+        }, $wpdb->get_results("SELECT * FROM {$optionTable} WHERE option_name LIKE 'wpj_job_%' ORDER BY option_id") ?: []);
     }
 
     public function saveJob(Job $job): bool

--- a/src/Connections/WordPressConnection.php
+++ b/src/Connections/WordPressConnection.php
@@ -10,9 +10,11 @@ class WordPressConnection extends Connection
     {
         global $wpdb;
 
+        $optionTable = $wpdb->prefix . 'options';
+
         return \array_map(function ($result) {
             return \unserialize($result->option_value);
-        }, $wpdb->get_results("SELECT * FROM wp_options WHERE option_name LIKE 'wpj_job_%' ORDER BY option_id") ?: []);
+        }, $wpdb->get_results("SELECT * FROM $optionTable WHERE option_name LIKE 'wpj_job_%' ORDER BY option_id") ?: []);
     }
 
     public function saveJob(Job $job): bool


### PR DESCRIPTION
Most of the cases, WordPress user changes the table prefix `wp_` to something else. This pull request is to fix `wp_options` table not found issue, thus working on, after changing the table prefix